### PR TITLE
Add rust-toolchain.toml file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+profile = "default"


### PR DESCRIPTION
This will select nightly for everyone without having to go through rustup override
