### PR TITLE
Greedy coloring

### DIFF
--- a/crates/algos/src/coloring.rs
+++ b/crates/algos/src/coloring.rs
@@ -1,10 +1,13 @@
-use graph_builder::SharedMut;
-use graph_builder::prelude::*;
-use rayon::prelude::*;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
-use std::sync::atomic::{AtomicBool, Ordering::{Relaxed, Acquire, Release}};
-use std::thread::available_parallelism;
 use crate::DEFAULT_PARALLELISM;
+use graph_builder::prelude::*;
+use graph_builder::SharedMut;
+use rayon::prelude::*;
+use std::sync::atomic::{
+    AtomicBool,
+    Ordering::{Acquire, Relaxed, Release},
+};
+use std::sync::atomic::{AtomicU64, AtomicUsize};
+use std::thread::available_parallelism;
 
 const CHUNK_SIZE: usize = 16384;
 
@@ -23,11 +26,11 @@ impl BitField {
         }
     }
 
-    fn update(&self, new_ids: Vec<usize>) {
+    fn update(&self, new_ids: &Vec<usize>) {
         let mut data = vec![0u64; self.data.len()];
-        for idx in new_ids {
+        for &idx in new_ids {
             data[idx >> 6] |= 1 << (idx & 63); //iff 63 = 2**uint - 1
-            // data[color / 64] |= 1 << (color % 64);
+                                               // data[color / 64] |= 1 << (color % 64);
         }
         for (idx, &new_word) in data.iter().enumerate() {
             self.data[idx].store(new_word, Release);
@@ -63,7 +66,7 @@ where
     NI: Idx,
     G: Graph<NI> + UndirectedNeighbors<NI> + UndirectedDegrees<NI> + Sync,
 {
-    let max_colors = config.max_colors.index(); //todo: add option to automatically pick and rerun if it was too small
+    let max_colors = config.max_colors.index(); //todo: add option to automatically pick and rerun if it was too small?
     assert_eq!(max_colors % 64, 0);
     let node_count = graph.node_count().index();
     let mut colors: Vec<usize> = vec![0; node_count]; //mutated through 'unsafe' use of pointer //init values not used, malloc?
@@ -88,7 +91,7 @@ where
         update_forbidden_colors(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden); //nodes to color, whose neighbors have been corrected, needs to get their forbidden_colors updated.
         nodes_to_color = find_incorrect_nodes(nodes_to_color, &colors_ptr, &color_forbidden);
     }
-    //todo: if any colors are 'free', reassign so that the highest colors get lower numbers.
+    colors = make_consecutive(colors);
     Ok(colors)
 }
 
@@ -108,26 +111,24 @@ where
     std::thread::scope(|s| {
         let num_threads = available_parallelism().map_or(DEFAULT_PARALLELISM, |p| p.get());
         for _ in 0..num_threads {
-            s.spawn(|| {
-                loop {
-                    let start = AtomicUsize::fetch_add(&next_chunk, CHUNK_SIZE, Acquire);
-                    if start >= nodes.len() {
-                        break;
-                    }
-                    let end = (start + CHUNK_SIZE).min(nodes.len());
+            s.spawn(|| loop {
+                let start = AtomicUsize::fetch_add(&next_chunk, CHUNK_SIZE, Acquire);
+                if start >= nodes.len() {
+                    break;
+                }
+                let end = (start + CHUNK_SIZE).min(nodes.len());
 
-                    for i in start..end {
-                        let u = nodes[i];
-                        if let Some(color) = color_forbidden[u.index()].trailing_zeros() {
-                            for v in graph.neighbors(u) {
-                                color_forbidden[v.index()].set(color);
-                            }
-                            unsafe {
-                                colors_ptr.add(u.index()).write(color);
-                            }
-                        } else {
-                            success.store(false, Relaxed);
+                for i in start..end {
+                    let u = nodes[i];
+                    if let Some(color) = color_forbidden[u.index()].trailing_zeros() {
+                        for v in graph.neighbors(u) {
+                            color_forbidden[v.index()].set(color);
                         }
+                        unsafe {
+                            colors_ptr.add(u.index()).write(color);
+                        }
+                    } else {
+                        success.store(false, Relaxed);
                     }
                 }
             });
@@ -164,15 +165,32 @@ fn update_forbidden_colors<G, NI>(
     NI: Idx,
 {
     {
-        nodes_to_color.into_par_iter().for_each(|v| unsafe { //todo: restrict #threads?
+        nodes_to_color.into_par_iter().for_each(|v| unsafe {
+            //todo: restrict #threads?
             //we only care for nodes_just_colored, but filter on them is probably more expensive than using all
             let nearby_colors = graph
                 .neighbors(*v)
                 .map(|u| colors_ptr.add(u.index()).read())
                 .collect();
-            color_forbidden[v.index()].update(nearby_colors); //each node writes to separate entry. Should be safe.
+            color_forbidden[v.index()].update(&nearby_colors); //each node writes to separate entry. Should be safe.
         });
     }
+}
+
+fn make_consecutive(mut colors: Vec<usize>) -> Vec<usize> {
+    let mut top_color = *colors.iter().max().unwrap();
+    let used_colors = BitField::new((top_color + 1) - (top_color + 1) % 64 + 64);
+    used_colors.update(&colors);
+    let free_colors = (0..=top_color).filter(|&color| !used_colors.is_set(color));
+    let mut color_map: Vec<usize> = (0..=top_color).collect();
+    for free_color in free_colors {
+        color_map[top_color] = free_color;
+        top_color -= 1;
+    }
+    colors
+        .iter_mut()
+        .for_each(|color| *color = color_map[*color]);
+    colors
 }
 
 pub mod tests {
@@ -202,7 +220,9 @@ pub mod tests {
             .build()
             .unwrap();
 
-        let coloring = coloring(&graph, GraphColoringConfig { max_colors: 64 }).ok().unwrap();
+        let coloring = coloring(&graph, GraphColoringConfig { max_colors: 64 })
+            .ok()
+            .unwrap();
         assert!(check_correct(&graph, &coloring));
     }
 }

--- a/crates/algos/src/coloring.rs
+++ b/crates/algos/src/coloring.rs
@@ -21,7 +21,6 @@ use std::thread::available_parallelism;
 ///      Concurrency: Pract. Exper., 12: 1131-1146.
 ///      https://doi.org/10.1002/1096-9128(200010)12:12<1131::AID-CPE528>3.0.CO;2-2
 /// [2] [Java] (https://github.com/neo4j/graph-data-science/blob/2dd419ed5a55d43bbaf0575d4bc34e517768d69f/algo/src/main/java/org/neo4j/gds/k1coloring/K1Coloring.java)
-
 const CHUNK_SIZE: usize = 16384;
 
 #[derive(Copy, Clone, Debug)]
@@ -32,11 +31,8 @@ pub struct ColoringConfig {
     #[cfg_attr(feature = "clap", clap(long, default_value_t = ColoringConfig::DEFAULT_CHUNK_SIZE))]
     pub chunk_size: usize,
 
-    /// Number of samples to draw from the DSS to find the largest component.
-    // #[cfg_attr(feature = "clap", clap(long, default_value_t = WccConfig::DEFAULT_SAMPLING_SIZE))]
-    // pub sampling_size: usize,
-
-    /// Number of samples to draw from the DSS to find the largest component.
+    /// Maximum number of colors, will be rounded up to nearest multiple of 64. Impacts memory
+    /// usage.
     #[cfg_attr(feature = "clap", clap(long, default_value_t = ColoringConfig::DEFAULT_MAX_COLORS))]
     pub max_colors: usize,
 }
@@ -55,7 +51,7 @@ impl ColoringConfig {
     pub const DEFAULT_MAX_COLORS: usize = 1024;
 
     pub fn new(chunk_size: usize, max_colors: usize) -> Self {
-        let max_colors = (max_colors + 63) / 64 * 64; // round up to next multiple of 64
+        let max_colors = max_colors.div_ceil(64) * 64; // round up to next multiple of 64
         Self {
             chunk_size,
             max_colors,
@@ -85,7 +81,6 @@ impl BitField {
     }
 
     fn is_set(&self, idx: usize) -> bool {
-        // self.data[idx / 64].load(Relaxed) >> (idx % 64) & 1 != 0
         self.data[idx >> 6].load(Relaxed) >> (idx & 63) & 1 != 0
     }
 
@@ -95,7 +90,7 @@ impl BitField {
 
     fn trailing_zeros(&self) -> Option<usize> {
         for (big_idx, bit_field_ref) in self.data.iter().enumerate() {
-            let bit_field = bit_field_ref.load(Acquire).clone();
+            let bit_field = bit_field_ref.load(Acquire);
             if bit_field != u64::MAX {
                 return Some((big_idx << 6) + ((!bit_field).trailing_zeros() as usize));
             }
@@ -104,7 +99,6 @@ impl BitField {
     }
 }
 
-#[inline(never)]
 pub fn coloring<NI, G>(graph: &G, config: ColoringConfig) -> Result<Vec<usize>, String>
 where
     NI: Idx,
@@ -114,15 +108,15 @@ where
     let node_count = graph.node_count().index();
     let mut colors: Vec<usize> = vec![0; node_count];
     let colors_ptr = SharedMut::new(colors.as_mut_ptr());
-    let mut color_forbidden = (0..node_count)
+    let mut color_forbidden: Vec<BitField> = (0..node_count)
         .into_par_iter()
         .map(|_| BitField::new(max_colors))
         .collect();
     let mut nodes_to_color: Vec<NI> = (0..node_count).map(NI::new).collect();
-    _ = assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)?;
+    assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)?;
     nodes_to_color = find_incorrect_nodes(nodes_to_color, &colors_ptr, &color_forbidden);
     while !nodes_to_color.is_empty() {
-        _ = assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)?;
+        assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)?;
         update_forbidden_colors(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden);
         nodes_to_color = find_incorrect_nodes(nodes_to_color, &colors_ptr, &color_forbidden);
     }
@@ -133,9 +127,9 @@ where
 #[inline(never)]
 fn assign_colors_in_parallel<NI, G>(
     graph: &G,
-    nodes: &Vec<NI>,
+    nodes: &[NI],
     colors_ptr: &SharedMut<usize>,
-    color_forbidden: &mut Vec<BitField>,
+    color_forbidden: &mut [BitField],
 ) -> Result<(), String>
 where
     NI: Idx,
@@ -153,8 +147,7 @@ where
                 }
                 let end = (start + CHUNK_SIZE).min(nodes.len());
 
-                for i in start..end {
-                    let u = nodes[i];
+                for &u in nodes.iter().take(end).skip(start) {
                     if let Some(color) = color_forbidden[u.index()].trailing_zeros() {
                         for v in graph.neighbors(u) {
                             color_forbidden[v.index()].set(color);
@@ -178,7 +171,7 @@ where
 fn find_incorrect_nodes<NI>(
     nodes: Vec<NI>,
     colors_ptr: &SharedMut<usize>,
-    color_forbidden: &Vec<BitField>,
+    color_forbidden: &[BitField],
 ) -> Vec<NI>
 where
     NI: Idx,
@@ -193,7 +186,7 @@ fn update_forbidden_colors<G, NI>(
     graph: &G,
     nodes_to_color: &Vec<NI>,
     colors_ptr: &SharedMut<usize>,
-    color_forbidden: &mut Vec<BitField>,
+    color_forbidden: &mut [BitField],
 ) where
     G: Graph<NI> + UndirectedNeighbors<NI> + UndirectedDegrees<NI> + Sync,
     NI: Idx,
@@ -225,13 +218,14 @@ fn make_consecutive(mut colors: Vec<usize>) -> Vec<usize> {
     colors
 }
 
+#[cfg(test)]
 pub mod tests {
     use crate::coloring::{coloring, ColoringConfig};
     use graph_builder::prelude::*;
 
     pub fn check_correct<NI: Idx, G: Graph<NI> + UndirectedNeighbors<NI>>(
         graph: &G,
-        color: &Vec<usize>,
+        color: &[usize],
     ) -> bool {
         for node in NI::zero().range(graph.node_count()) {
             for neighbor in graph.neighbors(node) {
@@ -254,5 +248,21 @@ pub mod tests {
 
         let coloring = coloring(&graph, ColoringConfig::default()).ok().unwrap();
         assert!(check_correct(&graph, &coloring));
+        assert_eq!(*coloring.iter().max().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_cycle() {
+        let gdl = "(a)-->()-->()-->()-->(a)";
+
+        let graph: UndirectedCsrGraph<usize> = GraphBuilder::new()
+            .csr_layout(CsrLayout::Deduplicated)
+            .gdl_str::<usize, _>(gdl)
+            .build()
+            .unwrap();
+
+        let coloring = coloring(&graph, ColoringConfig::default()).ok().unwrap();
+        assert!(check_correct(&graph, &coloring));
+        assert_eq!(*coloring.iter().max().unwrap(), 1);
     }
 }

--- a/crates/algos/src/coloring.rs
+++ b/crates/algos/src/coloring.rs
@@ -1,0 +1,215 @@
+use graph_builder::SharedMut;
+use graph_builder::prelude::*;
+use rayon::prelude::*;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, Ordering::{Relaxed, Acquire, Release}};
+use std::thread::available_parallelism;
+use std::time::Instant;
+use crate::DEFAULT_PARALLELISM;
+
+const CHUNK_SIZE: usize = 16384;
+
+pub struct GraphColoringConfig<NI> {
+    pub(crate) max_colors: NI,
+}
+struct BitField {
+    data: Vec<AtomicUsize>,
+}
+
+impl BitField {
+    fn new(capacity: usize) -> Self {
+        BitField {
+            //capacity / 64 = capacity >> 6 (64->32->16->8->4->2->1)
+            data: (0..(capacity >> 6)).map(|_| AtomicUsize::new(0)).collect(),
+        }
+    }
+
+    fn update(&self, new_ids: Vec<usize>) {
+        let mut data = vec![0usize; self.data.len()];
+        for idx in new_ids {
+            data[idx >> 6] |= 1 << (idx & 63); //iff 63 = 2**uint - 1
+            // data[color / 64] |= 1 << (color % 64);
+        }
+        for (idx, &new_word) in data.iter().enumerate() {
+            self.data[idx].store(new_word, Release); //little difference to relaxed
+        }
+    }
+
+    fn is_set(&self, idx: usize) -> bool {
+        // self.data[idx / 64].load(Relaxed) >> (idx % 64) & 1 != 0
+        self.data[idx >> 6].load(Relaxed) >> (idx & 63) & 1 != 0
+    }
+
+    fn set(&self, idx: usize) {
+        // self.data[idx / 64].fetch_or(1 << (idx % 64), Relaxed);
+        self.data[idx >> 6].fetch_or(1 << (idx & 63), Relaxed);
+    }
+
+    fn trailing_zeros(&self) -> Option<usize> {
+        for (big_idx, bit_field_) in self.data.iter().enumerate() {
+            let bit_field = bit_field_.load(Acquire).clone(); //little difference to relaxed
+            if bit_field != usize::MAX {
+                //not all ones
+                return Some((64 * big_idx) + ((!bit_field).trailing_zeros() as usize));
+            }
+        }
+        None
+    }
+}
+
+//Parallel speculation/correction-based greedy graph coloring
+// todo: add better description
+#[inline(never)]
+pub fn coloring<NI, G>(graph: &G, config: GraphColoringConfig<NI>) -> Result<Vec<usize>, String>
+where
+    NI: Idx,
+    G: Graph<NI> + UndirectedNeighbors<NI> + UndirectedDegrees<NI> + Sync,
+{
+    let max_colors = config.max_colors.index();
+    assert_eq!(max_colors % 64, 0);
+    let node_count = graph.node_count().index();
+    let mut colors: Vec<usize> = vec![0; node_count]; //mutated through 'unsafe' use of pointer //init values not used, malloc?
+    let colors_ptr = SharedMut::new(colors.as_mut_ptr());
+    let start = Instant::now();
+    let mut color_forbidden = (0..node_count)
+        .into_par_iter() //todo: parallelization had non-measurable impact on performance. also unlimited threads
+        .map(|_| BitField::new(max_colors))
+        .collect();
+    println!("{:?}", Instant::now()-start);
+    let mut nodes_to_color: Vec<NI> = (0..node_count).map(NI::new).collect();
+    if let Err(err) =
+        assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)
+    {
+        return Err(err);
+    }
+    nodes_to_color = find_incorrect_nodes(nodes_to_color, &colors_ptr, &color_forbidden);
+    while !nodes_to_color.is_empty() {
+        if let Err(err) =
+            assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)
+        {
+            return Err(err);
+        }
+        update_forbidden_colors(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden); //nodes to color, whose neighbors have been corrected, needs to get their forbidden_colors updated.
+        nodes_to_color = find_incorrect_nodes(nodes_to_color, &colors_ptr, &color_forbidden);
+    }
+    //todo: if any colors are 'free', reassign so that the highest colors get lower numbers.
+    Ok(colors)
+}
+
+#[inline(never)]
+fn assign_colors_in_parallel<NI, G>(
+    graph: &G,
+    nodes: &Vec<NI>,
+    colors_ptr: &SharedMut<usize>,
+    color_forbidden: &mut Vec<BitField>,
+) -> Result<(), String>
+where
+    NI: Idx,
+    G: Graph<NI> + UndirectedNeighbors<NI> + Sync,
+{
+    let success = AtomicBool::new(true);
+    let next_chunk = AtomicUsize::new(0);
+    std::thread::scope(|s| {
+        let num_threads = available_parallelism().map_or(DEFAULT_PARALLELISM, |p| p.get());
+        for _ in 0..num_threads {
+            s.spawn(|| {
+                loop {
+                    let start = AtomicUsize::fetch_add(&next_chunk, CHUNK_SIZE, Acquire);
+                    if start >= nodes.len() {
+                        break;
+                    }
+                    let end = (start + CHUNK_SIZE).min(nodes.len());
+
+                    for i in start..end {
+                        let u = nodes[i];
+                        if let Some(color) = color_forbidden[u.index()].trailing_zeros() {
+                            for v in graph.neighbors(u) {
+                                color_forbidden[v.index()].set(color);
+                            }
+                            unsafe {
+                                colors_ptr.add(u.index()).write(color);
+                            }
+                        } else {
+                            success.store(false, Relaxed);
+                        }
+                    }
+                }
+            });
+        }
+    });
+    if success.load(Relaxed) {
+        Ok(())
+    } else {
+        Err("Not enough colors :/".to_string())
+    }
+}
+
+fn find_incorrect_nodes<NI>(
+    nodes: Vec<NI>,
+    colors_ptr: &SharedMut<usize>,
+    color_forbidden: &Vec<BitField>,
+) -> Vec<NI>
+where
+    NI: Idx,
+{
+    nodes
+        .into_par_iter() //todo: restrict #threads?
+        .filter(|v| color_forbidden[v.index()].is_set(unsafe { colors_ptr.add(v.index()).read() }))
+        .collect()
+    // above is 4x faster (a few percentages in total on graph22
+    // nodes.retain(|v| color_forbidden[v.index()].is_set( unsafe { colors_ptr.add(v.index()).read() })); < this is neat though
+    // nodes
+}
+
+fn update_forbidden_colors<G, NI>(
+    graph: &G,
+    nodes_to_color: &Vec<NI>,
+    colors_ptr: &SharedMut<usize>,
+    color_forbidden: &mut Vec<BitField>,
+) where
+    G: Graph<NI> + UndirectedNeighbors<NI> + UndirectedDegrees<NI> + Sync,
+    NI: Idx,
+{
+    {
+        nodes_to_color.into_par_iter().for_each(|v| unsafe { //todo: restrict #threads?
+            //we only care for nodes_just_colored, but filter on them is probably more expensive than using all
+            let nearby_colors = graph
+                .neighbors(*v)
+                .map(|u| colors_ptr.add(u.index()).read())
+                .collect();
+            color_forbidden[v.index()].update(nearby_colors); //each node writes to separate entry. Should be safe.
+        });
+    }
+}
+
+pub mod tests {
+    use crate::coloring::{coloring, GraphColoringConfig};
+    use graph_builder::prelude::*;
+
+    pub fn check_correct<NI: Idx, G: Graph<NI> + UndirectedNeighbors<NI>>(
+        graph: &G,
+        color: &Vec<usize>,
+    ) -> bool {
+        for node in NI::zero().range(graph.node_count()) {
+            for neighbor in graph.neighbors(node) {
+                if color[node.index()] == color[neighbor.index()] {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+    #[test]
+    fn test_coloring_two_components() {
+        let gdl = "(a)-->()-->()<--(a),(b)-->()-->()<--(b)";
+
+        let graph: UndirectedCsrGraph<usize> = GraphBuilder::new()
+            .csr_layout(CsrLayout::Deduplicated)
+            .gdl_str::<usize, _>(gdl)
+            .build()
+            .unwrap();
+
+        let coloring = coloring(&graph, GraphColoringConfig { max_colors: 64 }).ok().unwrap();
+        assert!(check_correct(&graph, &coloring));
+    }
+}

--- a/crates/algos/src/coloring.rs
+++ b/crates/algos/src/coloring.rs
@@ -36,7 +36,7 @@ pub struct ColoringConfig {
     // #[cfg_attr(feature = "clap", clap(long, default_value_t = WccConfig::DEFAULT_SAMPLING_SIZE))]
     // pub sampling_size: usize,
 
-    /// Maximum number of colors to use (affects memory usage).
+    /// Number of samples to draw from the DSS to find the largest component.
     #[cfg_attr(feature = "clap", clap(long, default_value_t = ColoringConfig::DEFAULT_MAX_COLORS))]
     pub max_colors: usize,
 }
@@ -64,13 +64,12 @@ impl ColoringConfig {
 }
 
 struct BitField {
-    data: Vec<AtomicU64>, //(must be 64 bit!) but color as usize might be fine.
+    data: Vec<AtomicU64>,
 }
 
 impl BitField {
     fn new(capacity: usize) -> Self {
         BitField {
-            //capacity / 64 = capacity >> 6 (64->32->16->8->4->2->1)
             data: (0..(capacity >> 6)).map(|_| AtomicU64::new(0)).collect(),
         }
     }
@@ -78,8 +77,7 @@ impl BitField {
     fn update(&self, new_ids: &Vec<usize>) {
         let mut data = vec![0u64; self.data.len()];
         for &idx in new_ids {
-            data[idx >> 6] |= 1 << (idx & 63); //iff 63 = 2**uint - 1
-                                               // data[color / 64] |= 1 << (color % 64);
+            data[idx >> 6] |= 1 << (idx & 63);
         }
         for (idx, &new_word) in data.iter().enumerate() {
             self.data[idx].store(new_word, Release);
@@ -99,7 +97,6 @@ impl BitField {
         for (big_idx, bit_field_ref) in self.data.iter().enumerate() {
             let bit_field = bit_field_ref.load(Acquire).clone();
             if bit_field != u64::MAX {
-                //not all ones
                 return Some((big_idx << 6) + ((!bit_field).trailing_zeros() as usize));
             }
         }
@@ -107,36 +104,26 @@ impl BitField {
     }
 }
 
-//Parallel speculation/correction-based greedy graph coloring
-// todo: add better description
 #[inline(never)]
 pub fn coloring<NI, G>(graph: &G, config: ColoringConfig) -> Result<Vec<usize>, String>
 where
     NI: Idx,
     G: Graph<NI> + UndirectedNeighbors<NI> + UndirectedDegrees<NI> + Sync,
 {
-    let max_colors = config.max_colors.index(); //todo: add option to automatically pick and rerun if it was too small?
+    let max_colors = config.max_colors.index();
     let node_count = graph.node_count().index();
-    let mut colors: Vec<usize> = vec![0; node_count]; //mutated through 'unsafe' use of pointer //init values not used, malloc?
+    let mut colors: Vec<usize> = vec![0; node_count];
     let colors_ptr = SharedMut::new(colors.as_mut_ptr());
     let mut color_forbidden = (0..node_count)
-        .into_par_iter() //todo: parallelization had non-measurable impact on performance. also unlimited threads
+        .into_par_iter()
         .map(|_| BitField::new(max_colors))
         .collect();
     let mut nodes_to_color: Vec<NI> = (0..node_count).map(NI::new).collect();
-    if let Err(err) =
-        assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)
-    {
-        return Err(err);
-    }
+    _ = assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)?;
     nodes_to_color = find_incorrect_nodes(nodes_to_color, &colors_ptr, &color_forbidden);
     while !nodes_to_color.is_empty() {
-        if let Err(err) =
-            assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)
-        {
-            return Err(err);
-        }
-        update_forbidden_colors(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden); //nodes to color, whose neighbors have been corrected, needs to get their forbidden_colors updated.
+        _ = assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)?;
+        update_forbidden_colors(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden);
         nodes_to_color = find_incorrect_nodes(nodes_to_color, &colors_ptr, &color_forbidden);
     }
     colors = make_consecutive(colors);
@@ -182,11 +169,10 @@ where
             });
         }
     });
-    if success.load(Relaxed) {
-        Ok(())
-    } else {
-        Err("Not enough colors :/".to_string())
-    }
+    success
+        .load(Relaxed)
+        .then_some(())
+        .ok_or_else(|| "Not enough colors!".to_string())
 }
 
 fn find_incorrect_nodes<NI>(
@@ -198,7 +184,7 @@ where
     NI: Idx,
 {
     nodes
-        .into_par_iter() //todo: restrict #threads?
+        .into_par_iter()
         .filter(|v| color_forbidden[v.index()].is_set(unsafe { colors_ptr.add(v.index()).read() }))
         .collect()
 }
@@ -214,13 +200,11 @@ fn update_forbidden_colors<G, NI>(
 {
     {
         nodes_to_color.into_par_iter().for_each(|v| unsafe {
-            //todo: restrict #threads?
-            //we only care for nodes_just_colored, but filter on them is probably more expensive than using all
             let nearby_colors = graph
                 .neighbors(*v)
                 .map(|u| colors_ptr.add(u.index()).read())
                 .collect();
-            color_forbidden[v.index()].update(&nearby_colors); //each node writes to separate entry. Should be safe.
+            color_forbidden[v.index()].update(&nearby_colors);
         });
     }
 }

--- a/crates/algos/src/coloring.rs
+++ b/crates/algos/src/coloring.rs
@@ -1,10 +1,9 @@
 use graph_builder::SharedMut;
 use graph_builder::prelude::*;
 use rayon::prelude::*;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::atomic::{AtomicBool, Ordering::{Relaxed, Acquire, Release}};
 use std::thread::available_parallelism;
-use std::time::Instant;
 use crate::DEFAULT_PARALLELISM;
 
 const CHUNK_SIZE: usize = 16384;
@@ -13,25 +12,25 @@ pub struct GraphColoringConfig<NI> {
     pub(crate) max_colors: NI,
 }
 struct BitField {
-    data: Vec<AtomicUsize>,
+    data: Vec<AtomicU64>, //(must be 64 bit!) but color as usize might be fine.
 }
 
 impl BitField {
     fn new(capacity: usize) -> Self {
         BitField {
             //capacity / 64 = capacity >> 6 (64->32->16->8->4->2->1)
-            data: (0..(capacity >> 6)).map(|_| AtomicUsize::new(0)).collect(),
+            data: (0..(capacity >> 6)).map(|_| AtomicU64::new(0)).collect(),
         }
     }
 
     fn update(&self, new_ids: Vec<usize>) {
-        let mut data = vec![0usize; self.data.len()];
+        let mut data = vec![0u64; self.data.len()];
         for idx in new_ids {
             data[idx >> 6] |= 1 << (idx & 63); //iff 63 = 2**uint - 1
             // data[color / 64] |= 1 << (color % 64);
         }
         for (idx, &new_word) in data.iter().enumerate() {
-            self.data[idx].store(new_word, Release); //little difference to relaxed
+            self.data[idx].store(new_word, Release);
         }
     }
 
@@ -41,16 +40,15 @@ impl BitField {
     }
 
     fn set(&self, idx: usize) {
-        // self.data[idx / 64].fetch_or(1 << (idx % 64), Relaxed);
         self.data[idx >> 6].fetch_or(1 << (idx & 63), Relaxed);
     }
 
     fn trailing_zeros(&self) -> Option<usize> {
-        for (big_idx, bit_field_) in self.data.iter().enumerate() {
-            let bit_field = bit_field_.load(Acquire).clone(); //little difference to relaxed
-            if bit_field != usize::MAX {
+        for (big_idx, bit_field_ref) in self.data.iter().enumerate() {
+            let bit_field = bit_field_ref.load(Acquire).clone();
+            if bit_field != u64::MAX {
                 //not all ones
-                return Some((64 * big_idx) + ((!bit_field).trailing_zeros() as usize));
+                return Some((big_idx << 6) + ((!bit_field).trailing_zeros() as usize));
             }
         }
         None
@@ -65,17 +63,15 @@ where
     NI: Idx,
     G: Graph<NI> + UndirectedNeighbors<NI> + UndirectedDegrees<NI> + Sync,
 {
-    let max_colors = config.max_colors.index();
+    let max_colors = config.max_colors.index(); //todo: add option to automatically pick and rerun if it was too small
     assert_eq!(max_colors % 64, 0);
     let node_count = graph.node_count().index();
     let mut colors: Vec<usize> = vec![0; node_count]; //mutated through 'unsafe' use of pointer //init values not used, malloc?
     let colors_ptr = SharedMut::new(colors.as_mut_ptr());
-    let start = Instant::now();
     let mut color_forbidden = (0..node_count)
         .into_par_iter() //todo: parallelization had non-measurable impact on performance. also unlimited threads
         .map(|_| BitField::new(max_colors))
         .collect();
-    println!("{:?}", Instant::now()-start);
     let mut nodes_to_color: Vec<NI> = (0..node_count).map(NI::new).collect();
     if let Err(err) =
         assign_colors_in_parallel(graph, &nodes_to_color, &colors_ptr, &mut color_forbidden)
@@ -156,9 +152,6 @@ where
         .into_par_iter() //todo: restrict #threads?
         .filter(|v| color_forbidden[v.index()].is_set(unsafe { colors_ptr.add(v.index()).read() }))
         .collect()
-    // above is 4x faster (a few percentages in total on graph22
-    // nodes.retain(|v| color_forbidden[v.index()].is_set( unsafe { colors_ptr.add(v.index()).read() })); < this is neat though
-    // nodes
 }
 
 fn update_forbidden_colors<G, NI>(

--- a/crates/algos/src/coloring.rs
+++ b/crates/algos/src/coloring.rs
@@ -9,6 +9,19 @@ use std::sync::atomic::{
 use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::thread::available_parallelism;
 
+/// Graph coloring assigns a color to every node so that
+/// 1. No node has a neighbor with the same color
+/// 2. The total number of colors is as low as possible.
+///
+/// Finding the lowest possible number of colors is an NP-complete problem. This implementation,
+/// based on the speculation/correction paradigm of [1], instead uses a parallel greedy algorithm
+/// to find a solution with few-enough colors. See [2] for a Java implementation.
+///
+/// [1]  Gebremedhin, A.H. and Manne, F. (2000), Scalable parallel graph coloring algorithms.
+///      Concurrency: Pract. Exper., 12: 1131-1146.
+///      https://doi.org/10.1002/1096-9128(200010)12:12<1131::AID-CPE528>3.0.CO;2-2
+/// [2] [Java] (https://github.com/neo4j/graph-data-science/blob/2dd419ed5a55d43bbaf0575d4bc34e517768d69f/algo/src/main/java/org/neo4j/gds/k1coloring/K1Coloring.java)
+
 const CHUNK_SIZE: usize = 16384;
 
 pub struct GraphColoringConfig<NI> {

--- a/crates/algos/src/coloring.rs
+++ b/crates/algos/src/coloring.rs
@@ -24,9 +24,45 @@ use std::thread::available_parallelism;
 
 const CHUNK_SIZE: usize = 16384;
 
-pub struct GraphColoringConfig<NI> {
-    pub(crate) max_colors: NI,
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+pub struct ColoringConfig {
+    /// Number of nodes to be processed in batch by a single thread.
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = ColoringConfig::DEFAULT_CHUNK_SIZE))]
+    pub chunk_size: usize,
+
+    /// Number of samples to draw from the DSS to find the largest component.
+    // #[cfg_attr(feature = "clap", clap(long, default_value_t = WccConfig::DEFAULT_SAMPLING_SIZE))]
+    // pub sampling_size: usize,
+
+    /// Maximum number of colors to use (affects memory usage).
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = ColoringConfig::DEFAULT_MAX_COLORS))]
+    pub max_colors: usize,
 }
+
+impl Default for ColoringConfig {
+    fn default() -> Self {
+        Self {
+            chunk_size: ColoringConfig::DEFAULT_CHUNK_SIZE,
+            max_colors: ColoringConfig::DEFAULT_MAX_COLORS,
+        }
+    }
+}
+
+impl ColoringConfig {
+    pub const DEFAULT_CHUNK_SIZE: usize = 16384;
+    pub const DEFAULT_MAX_COLORS: usize = 1024;
+
+    pub fn new(chunk_size: usize, max_colors: usize) -> Self {
+        let max_colors = (max_colors + 63) / 64 * 64; // round up to next multiple of 64
+        Self {
+            chunk_size,
+            max_colors,
+        }
+    }
+}
+
 struct BitField {
     data: Vec<AtomicU64>, //(must be 64 bit!) but color as usize might be fine.
 }
@@ -74,13 +110,12 @@ impl BitField {
 //Parallel speculation/correction-based greedy graph coloring
 // todo: add better description
 #[inline(never)]
-pub fn coloring<NI, G>(graph: &G, config: GraphColoringConfig<NI>) -> Result<Vec<usize>, String>
+pub fn coloring<NI, G>(graph: &G, config: ColoringConfig) -> Result<Vec<usize>, String>
 where
     NI: Idx,
     G: Graph<NI> + UndirectedNeighbors<NI> + UndirectedDegrees<NI> + Sync,
 {
     let max_colors = config.max_colors.index(); //todo: add option to automatically pick and rerun if it was too small?
-    assert_eq!(max_colors % 64, 0);
     let node_count = graph.node_count().index();
     let mut colors: Vec<usize> = vec![0; node_count]; //mutated through 'unsafe' use of pointer //init values not used, malloc?
     let colors_ptr = SharedMut::new(colors.as_mut_ptr());
@@ -207,7 +242,7 @@ fn make_consecutive(mut colors: Vec<usize>) -> Vec<usize> {
 }
 
 pub mod tests {
-    use crate::coloring::{coloring, GraphColoringConfig};
+    use crate::coloring::{coloring, ColoringConfig};
     use graph_builder::prelude::*;
 
     pub fn check_correct<NI: Idx, G: Graph<NI> + UndirectedNeighbors<NI>>(
@@ -233,9 +268,7 @@ pub mod tests {
             .build()
             .unwrap();
 
-        let coloring = coloring(&graph, GraphColoringConfig { max_colors: 64 })
-            .ok()
-            .unwrap();
+        let coloring = coloring(&graph, ColoringConfig::default()).ok().unwrap();
         assert!(check_correct(&graph, &coloring));
     }
 }

--- a/crates/algos/src/lib.rs
+++ b/crates/algos/src/lib.rs
@@ -149,6 +149,7 @@ pub mod sssp;
 pub mod triangle_count;
 pub mod utils;
 pub mod wcc;
+
 const DEFAULT_PARALLELISM: usize = 4;
 
 // Related to https://github.com/rust-lang/rust/issues/72686

--- a/crates/algos/src/lib.rs
+++ b/crates/algos/src/lib.rs
@@ -141,6 +141,7 @@
 //! ```
 
 pub mod afforest;
+pub mod coloring;
 pub mod dss;
 pub mod page_rank;
 pub mod prelude;
@@ -148,7 +149,6 @@ pub mod sssp;
 pub mod triangle_count;
 pub mod utils;
 pub mod wcc;
-
 const DEFAULT_PARALLELISM: usize = 4;
 
 // Related to https://github.com/rust-lang/rust/issues/72686


### PR DESCRIPTION
Gebremedhin-Manne's speculation-correction parallelization of greedy coloring. To be used as it is or as part of parallelizing other algorithms (eg. Louvain). It colors graph500-22 with 420-450 colors and runs slightly faster than the graph is built from in-memory edge list.