### PR TITLE
Fix "TARmageddon" vulnerability CVE-2025-62518

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tap = "1.0.1"
 tempfile = "3.7.0"
 thiserror = "1.0.44"
 tokio = { version = "1.29.1", features = ["full"], default-features = true }
-tokio-tar = "0.3.1"
+astral-tokio-tar = "0.5.6"
 tokio-util = {version = "0.7.8", features = ["io"] }
 tonic = "0.9"
 


### PR DESCRIPTION
switch to astral-tokio-tar which is maintained.