### PR TITLE
Fix EdgeList::edges() compilation with rayon >= 1.10

### DIFF
--- a/crates/builder/src/input/edgelist.rs
+++ b/crates/builder/src/input/edgelist.rs
@@ -122,7 +122,7 @@ impl<NI: Idx, EV: Copy + Send + Sync> Edges for EdgeList<NI, EV> {
         Self: 'a;
 
     fn edges(&self) -> Self::EdgeIter<'_> {
-        self.list.into_par_iter().copied()
+        self.list.par_iter().copied()
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Summary

- `EdgeList::edges()` in `crates/builder/src/input/edgelist.rs` calls `self.list.into_par_iter().copied()` where `self.list` is `Box<[(NI, NI, EV)]>`
- In rayon 1.10+, `IntoParallelIterator` for `Box<[T]>` yields owned `T` items, so `.copied()` fails because it requires `Item = &'a T`
- Fix: use `par_iter()` instead of `into_par_iter()`, which produces `rayon::slice::Iter` yielding `&T` — matching the declared return type `Copied<rayon::slice::Iter<'a, ...>>`

## Test plan

- [x] `cargo check -p graph_builder` compiles cleanly
- [x] `cargo test -p graph_builder` — all 70 tests pass (53 unit + 17 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)