### PR TITLE
Upgrade to Rust 1.91, bump all dependencies, raise Python floor to 3.10

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   PY_PACKAGE_NAME: "graph_mate"
-  PYTHON_VERSION: "3.8" # to build abi3 wheels
+  PYTHON_VERSION: "3.10" # to build abi3 wheels
   MATURIN_ARGS: "--features extension-module --manifest-path crates/mate/Cargo.toml --release --out dist"
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,59 +8,67 @@ authors = [
     "Martin Junghanns <github@s1ck.dev>",
     "Paul Horn <developer@knutwalker.de>",
 ]
-rust-version = "1.70"
+rust-version = "1.86"
 repository = "https://github.com/neo4j-labs/graph"
 edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-ahash = "0.8.3"
-arrow = "45.0.0"
-arrow-flight = "45.0.0"
-async-compression = { version = "0.3.15", features = ["tokio", "stream", "zstd"] }
-async-trait = "0.1.72"
-atoi = "2.0.0"
-atomic = "0.5.3"
-atomic_float = "0.1.0"
-byte-slice-cast = "1.2.2"
-clap = { version = "4.3", features = ["derive"] }
-criterion = { version = "0.4.0", features = ["html_reports"] }
-dashmap = "5.5.0"
-delegate = "0.8.0"
-directories = "4.0"
-env_logger = "0.9.3"
+ahash = "0.8.12"
+arrow = "59.0.0"
+arrow-flight = "59.0.0"
+async-compression = { version = "0.4.42", features = ["tokio", "zstd"] }
+async-trait = "0.1.89"
+atoi = "3.0.0"
+atomic = "0.6.1"
+atomic_float = "1.1.0"
+byte-slice-cast = "1.2.3"
+bytemuck = "1.24.0"
+clap = { version = "4.6", features = ["derive"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
+dashmap = "6.2.1"
+delegate = "0.13.5"
+directories = "6.0.0"
+env_logger = "0.11.10"
 fast-float2 = "0.2.3"
 float-ord = "0.3.2"
-futures = "0.3.28"
+futures = "0.3.32"
 fxhash = "0.2.1"
 gdl = "0.2.7"
-itertools = "0.10.5"
+itertools = "0.14.0"
 linereader = "0.4.0"
-log = "0.4.19"
-memmap2 = "0.5.10"
-nanorand = "0.7.0"
-num = "0.4.1"
-num_cpus = "1.16.0"
+log = "0.4.32"
+memmap2 = "0.9.10"
+nanorand = "0.8.0"
+num = "0.4.3"
+num_cpus = "1.17.0"
 num-format = "0.4.4"
-numpy = "0.17.2"
-page_size = "0.4.2"
-parking_lot = "0.12.1"
+numpy = "0.28.0"
+page_size = "0.6.0"
+parking_lot = "0.12.5"
 pico-args = "0.5.0"
-polars = { version = "0.25.1", default_features = false, features = ["fmt"] }
-pyo3 = "0.17.3"
-pyo3-log = "0.7.0"
-rand = "0.8.5"
-rayon = "1.7.0"
-reqwest = { version = "0.11", features = ["stream"] }
-serde_json = "1.0.103"
-serde = { version = "1.0.174", features = ["derive"] }
+polars = { version = "0.54.4", default-features = false, features = ["fmt"] }
+pyo3 = { version = "0.28.3", default-features = false }
+pyo3-log = "0.13.3"
+rand = "0.10.1"
+rayon = "1.12.0"
+reqwest = { version = "0.13.4", features = ["stream"] }
+serde_json = "1.0.150"
+serde = { version = "1.0.228", features = ["derive"] }
 tap = "1.0.1"
-tempfile = "3.7.0"
-thiserror = "1.0.44"
-tokio = { version = "1.29.1", features = ["full"], default-features = true }
+tempfile = "3.27.0"
+thiserror = "2.0.18"
+tokio = { version = "1.52.3", features = ["full"], default-features = true }
 tokio-tar = "0.3.1"
-tokio-util = {version = "0.7.8", features = ["io"] }
-tonic = "0.9"
+tokio-util = { version = "0.7.18", features = ["io"] }
+tonic = "0.14.6"
+tonic-prost = "0.14.6"
 
 [workspace.metadata.release]
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tap = "1.0.1"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"], default-features = true }
-tokio-tar = "0.3.1"
+astral-tokio-tar = "0.6.2"
 tokio-util = { version = "0.7.18", features = ["io"] }
 tonic = "0.14.6"
 tonic-prost = "0.14.6"

--- a/crates/algos/examples/usage-demo.rs
+++ b/crates/algos/examples/usage-demo.rs
@@ -32,22 +32,25 @@ fn main() -> AppResult {
     info!("PageRank ran iterations: {iterations}");
 
     // Let's convert the scores to a polars DataFrame.
-    let df = DataFrame::new(vec![Series::new("scores", scores)])?;
+    let height = scores.len();
+    let df = DataFrame::new(height, vec![Column::new("scores".into(), scores)])?;
     // We can now calculate some statistics on the result.
     info!("size = {}", df.height());
-    info!("min = {}", df.min());
-    info!("max = {}", df.max());
-    info!("mean = {}", df.mean());
-    info!("median = {}", df.median());
+    let scores = df.column("scores")?.as_materialized_series();
+    info!("min = {:?}", scores.min::<f32>()?);
+    info!("max = {:?}", scores.max::<f32>()?);
+    info!("mean = {:?}", scores.mean());
+    info!("median = {:?}", scores.median());
 
     // Now we want to run Weakly Connected Components on the graph.
     // Similar to the Page Rank result, we get the component id for each node.
     let components = time(|| wcc_afforest(&g, WccConfig::default())).to_vec();
 
     // Calculate some statistics on the computed components.
-    let df = DataFrame::new(vec![Series::new("components", components)])?;
+    let height = components.len();
+    let df = DataFrame::new(height, vec![Column::new("components".into(), components)])?;
     info!("size = {}", df.height());
-    let df = df.unique(None, UniqueKeepStrategy::First)?;
+    let df = df.unique::<Vec<String>, String>(None, UniqueKeepStrategy::First, None)?;
     info!("component count = {}", df.height());
 
     // Now we want to count the total number of triangles in the graph.

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -39,7 +39,7 @@ rand.workspace = true
 reqwest.workspace = true
 tap.workspace = true
 tempfile.workspace = true
-tokio-tar.workspace = true
+astral-tokio-tar.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 atoi.workspace = true
 atomic.workspace = true
 byte-slice-cast.workspace = true
+bytemuck.workspace = true
 dashmap.workspace = true
 delegate.workspace = true
 fast-float2.workspace = true
@@ -65,6 +66,7 @@ harness = false
 [[bench]]
 name = "dotgraph"
 harness = false
+required-features = ["dotgraph"]
 
 [package.metadata.docs.rs]
 features = ["gdl", "dotgraph"]

--- a/crates/builder/benches/common/mod.rs
+++ b/crates/builder/benches/common/mod.rs
@@ -42,7 +42,7 @@ pub fn create_graph_500(scale: usize) -> Result<PathBuf> {
 
 async fn download_and_decompress<P: AsRef<Path>>(url: &str, download: P) -> Result<()> {
     let response = reqwest::get(url).await?.bytes_stream();
-    let response = response.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+    let response = response.map_err(std::io::Error::other);
     let bufread = tokio_util::io::StreamReader::new(response);
     let bufread = async_compression::tokio::bufread::ZstdDecoder::new(bufread);
     let bufread = tokio::io::BufReader::new(bufread);
@@ -99,8 +99,8 @@ where
 
     (0..edge_count)
         .map(|_| {
-            let source = NI::new(rng.gen_range(0..node_count));
-            let target = NI::new(rng.gen_range(0..node_count));
+            let source = NI::new(rng.random_range(0..node_count));
+            let target = NI::new(rng.random_range(0..node_count));
 
             (source, target, edge_value(source, target))
         })

--- a/crates/builder/benches/dotgraph.rs
+++ b/crates/builder/benches/dotgraph.rs
@@ -1,8 +1,9 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
 use graph_builder::prelude::*;
+use std::hint::black_box;
 
 use graph_builder::input::dotgraph::{LabelStats, NodeLabelIndex};
-use rand::Rng;
+use rand::RngExt;
 
 mod common;
 use common::*;
@@ -20,7 +21,7 @@ fn label_stats(c: &mut Criterion) {
 }
 
 fn bench_label_stats(b: &mut criterion::Bencher, Input { node_count, .. }: Input) {
-    let labels = node_values(node_count, |_node, rng| rng.gen_range(0..42));
+    let labels = node_values(node_count, |_node, rng| rng.random_range(0..42));
     let graph: UndirectedCsrGraph<usize, usize> = GraphBuilder::new()
         .edges([(0, node_count - 1)])
         .node_values(labels.clone())
@@ -41,7 +42,7 @@ fn node_label_index(c: &mut Criterion) {
 }
 
 fn bench_node_label_index(b: &mut criterion::Bencher, Input { node_count, .. }: Input) {
-    let labels = node_values(node_count, |_node, rng| rng.gen_range(0..42));
+    let labels = node_values(node_count, |_node, rng| rng.random_range(0..42));
     let graph: UndirectedCsrGraph<usize, usize> = GraphBuilder::new()
         .edges([(0, node_count - 1)])
         .node_values(labels.clone())

--- a/crates/builder/benches/edgelist.rs
+++ b/crates/builder/benches/edgelist.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
 use graph_builder::prelude::*;
+use std::hint::black_box;
 
 mod common;
 use common::*;

--- a/crates/builder/benches/topology.rs
+++ b/crates/builder/benches/topology.rs
@@ -2,6 +2,7 @@ use criterion::measurement::WallTime;
 use criterion::*;
 use graph_builder::graph::csr::Csr;
 use graph_builder::prelude::*;
+use std::hint::black_box;
 
 use graph_builder::graph::adj_list::{AdjacencyList, DirectedALGraph};
 

--- a/crates/builder/src/builder.rs
+++ b/crates/builder/src/builder.rs
@@ -322,7 +322,7 @@ impl GraphBuilder<Uninitialized> {
     /// ```
     #[cfg(feature = "gdl")]
     #[cfg_attr(all(feature = "gdl", has_doc_cfg), doc(cfg(feature = "gdl")))]
-    pub fn gdl_graph<NI>(self, gdl_graph: &::gdl::Graph) -> GraphBuilder<FromGdlGraph<NI>>
+    pub fn gdl_graph<NI>(self, gdl_graph: &::gdl::Graph) -> GraphBuilder<FromGdlGraph<'_, NI>>
     where
         NI: Idx,
     {

--- a/crates/builder/src/index.rs
+++ b/crates/builder/src/index.rs
@@ -3,8 +3,9 @@ use std::iter::Sum;
 use std::ops::{Range, RangeInclusive};
 use std::sync::atomic::Ordering;
 
-use atoi::FromRadix10;
+use atoi::{FromRadix10, FromRadix10Signed};
 use atomic::Atomic;
+use bytemuck::NoUninit;
 
 pub trait Idx:
     Copy
@@ -19,6 +20,7 @@ pub trait Idx:
     + Sum
     + Sync
     + Sized
+    + NoUninit
     + 'static
 {
     fn new(idx: usize) -> Self;
@@ -46,6 +48,9 @@ pub trait Idx:
 
 macro_rules! impl_idx {
     ($TYPE:ty) => {
+        impl_idx!($TYPE, $TYPE, FromRadix10::from_radix_10);
+    };
+    ($TYPE:ty, $PARSE:ty, $parse_fn:path) => {
         impl Idx for $TYPE {
             #[inline]
             fn new(idx: usize) -> Self {
@@ -79,7 +84,8 @@ macro_rules! impl_idx {
 
             #[inline]
             fn parse(bytes: &[u8]) -> (Self, usize) {
-                FromRadix10::from_radix_10(bytes)
+                let (value, len): ($PARSE, usize) = $parse_fn(bytes);
+                (value as $TYPE, len)
             }
 
             #[inline]
@@ -94,10 +100,10 @@ impl_idx!(u8);
 impl_idx!(u16);
 impl_idx!(u32);
 impl_idx!(u64);
-impl_idx!(usize);
+impl_idx!(usize, u64, FromRadix10::from_radix_10);
 
-impl_idx!(i8);
-impl_idx!(i16);
-impl_idx!(i32);
-impl_idx!(i64);
-impl_idx!(isize);
+impl_idx!(i8, i8, FromRadix10Signed::from_radix_10_signed);
+impl_idx!(i16, i16, FromRadix10Signed::from_radix_10_signed);
+impl_idx!(i32, i32, FromRadix10Signed::from_radix_10_signed);
+impl_idx!(i64, i64, FromRadix10Signed::from_radix_10_signed);
+impl_idx!(isize, i64, FromRadix10Signed::from_radix_10_signed);

--- a/crates/builder/src/input/dotgraph.rs
+++ b/crates/builder/src/input/dotgraph.rs
@@ -359,7 +359,7 @@ where
         self.len() == 0
     }
 
-    pub fn iter(&self) -> std::collections::hash_map::Iter<Label, usize> {
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, Label, usize> {
         self.map.iter()
     }
 }

--- a/crates/builder/src/input/edgelist.rs
+++ b/crates/builder/src/input/edgelist.rs
@@ -122,7 +122,7 @@ impl<NI: Idx, EV: Copy + Send + Sync> Edges for EdgeList<NI, EV> {
         Self: 'a;
 
     fn edges(&self) -> Self::EdgeIter<'_> {
-        self.list.into_par_iter().copied()
+        self.list.par_iter().copied()
     }
 
     #[cfg(test)]

--- a/crates/builder/src/input/mod.rs
+++ b/crates/builder/src/input/mod.rs
@@ -80,15 +80,18 @@ macro_rules! impl_parse_value {
     };
 }
 
-impl_parse_value!(
-    ::atoi::FromRadix10::from_radix_10,
-    u8,
-    u16,
-    u32,
-    u64,
-    u128,
-    usize,
-);
+impl_parse_value!(::atoi::FromRadix10::from_radix_10, u8, u16, u32, u64, u128,);
+
+impl ParseValue for usize {
+    fn parse(bytes: &[u8]) -> (Self, usize) {
+        if bytes.is_empty() {
+            (0, 0)
+        } else {
+            let (value, len): (u64, usize) = ::atoi::FromRadix10::from_radix_10(bytes);
+            (value as usize, len)
+        }
+    }
+}
 
 impl_parse_value!(
     ::atoi::FromRadix10Signed::from_radix_10_signed,
@@ -97,8 +100,18 @@ impl_parse_value!(
     i32,
     i64,
     i128,
-    isize,
 );
+
+impl ParseValue for isize {
+    fn parse(bytes: &[u8]) -> (Self, usize) {
+        if bytes.is_empty() {
+            (0, 0)
+        } else {
+            let (value, len): (i64, usize) = ::atoi::FromRadix10Signed::from_radix_10_signed(bytes);
+            (value as isize, len)
+        }
+    }
+}
 
 impl_parse_value!(parse_float, f32, f64);
 

--- a/crates/mate/Cargo.toml
+++ b/crates/mate/Cargo.toml
@@ -29,7 +29,7 @@ rayon.workspace = true
 
 [dependencies.pyo3]
 workspace = true
-features = ["macros", "auto-initialize", "abi3", "abi3-py38"]
+features = ["macros", "auto-initialize", "abi3", "abi3-py310"]
 default-features = false
 
 [[package.metadata.release.pre-release-replacements]]

--- a/crates/mate/Cargo.toml
+++ b/crates/mate/Cargo.toml
@@ -29,7 +29,7 @@ rayon.workspace = true
 
 [dependencies.pyo3]
 workspace = true
-features = ["macros", "pyproto", "auto-initialize", "abi3", "abi3-py38"]
+features = ["macros", "auto-initialize", "abi3", "abi3-py38"]
 default-features = false
 
 [[package.metadata.release.pre-release-replacements]]

--- a/crates/mate/pyproject.toml
+++ b/crates/mate/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries",
 ]

--- a/crates/mate/pyproject.toml
+++ b/crates/mate/pyproject.toml
@@ -5,15 +5,13 @@ build-backend = "maturin"
 [project]
 name = "graph_mate"
 version = "0.1.1"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/crates/mate/src/graphs/digraph.rs
+++ b/crates/mate/src/graphs/digraph.rs
@@ -9,7 +9,7 @@ use numpy::{PyArray1, PyArray2};
 use pyo3::{prelude::*, types::PyList};
 use std::path::PathBuf;
 
-pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DiGraph>()?;
     Ok(())
 }
@@ -32,7 +32,7 @@ impl DiGraph {
 impl DiGraph {
     /// Load a graph in the provided format
     #[staticmethod]
-    #[args(layout = "None", file_format = "FileFormat::Graph500")]
+    #[pyo3(signature = (path, layout = None, file_format = FileFormat::Graph500))]
     pub fn load(
         py: Python<'_>,
         path: PathBuf,
@@ -45,16 +45,16 @@ impl DiGraph {
 
     /// Convert a numpy 2d-array into a graph.
     #[staticmethod]
-    #[args(layout = "None")]
-    pub fn from_numpy(np: &PyArray2<u32>, layout: Option<Layout>) -> PyResult<Self> {
+    #[pyo3(signature = (np, layout = None))]
+    pub fn from_numpy(np: &Bound<'_, PyArray2<u32>>, layout: Option<Layout>) -> PyResult<Self> {
         let g = PyGraph::from_numpy(np, layout)?;
         Ok(Self::new(g.load_micros, g))
     }
 
     /// Convert a pandas dataframe into a graph.
     #[staticmethod]
-    #[args(layout = "None")]
-    pub fn from_pandas(py: Python<'_>, data: PyObject, layout: Option<Layout>) -> PyResult<Self> {
+    #[pyo3(signature = (data, layout = None))]
+    pub fn from_pandas(py: Python<'_>, data: Py<PyAny>, layout: Option<Layout>) -> PyResult<Self> {
         let g = PyGraph::from_pandas(py, data, layout)?;
         Ok(Self::new(g.load_micros, g))
     }
@@ -84,7 +84,11 @@ impl DiGraph {
     ///
     /// This functions returns a numpy array that directly references this graph without
     /// making a copy of the data.
-    pub fn out_neighbors<'py>(&self, py: Python<'py>, node: u32) -> PyResult<&'py PyArray1<u32>> {
+    pub fn out_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: u32,
+    ) -> PyResult<Bound<'py, PyArray1<u32>>> {
         self.inner.out_neighbors(py, node)
     }
 
@@ -93,7 +97,11 @@ impl DiGraph {
     ///
     /// This functions returns a numpy array that directly references this graph without
     /// making a copy of the data.
-    pub fn in_neighbors<'py>(&self, py: Python<'py>, node: u32) -> PyResult<&'py PyArray1<u32>> {
+    pub fn in_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: u32,
+    ) -> PyResult<Bound<'py, PyArray1<u32>>> {
         self.inner.in_neighbors(py, node)
     }
 
@@ -101,7 +109,11 @@ impl DiGraph {
     /// i.e., the given node is the source node of the connecting edge.
     ///
     /// This function returns a copy of the data as a Python list.
-    pub fn copy_out_neighbors<'py>(&self, py: Python<'py>, node: u32) -> &'py PyList {
+    pub fn copy_out_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: u32,
+    ) -> PyResult<Bound<'py, PyList>> {
         self.inner.copy_out_neighbors(py, node)
     }
 
@@ -109,7 +121,11 @@ impl DiGraph {
     /// i.e., the given node is the target node of theconnecting edge.
     ///
     /// This function returns a copy of the data as a Python list.
-    pub fn copy_in_neighbors<'py>(&self, py: Python<'py>, node: u32) -> &'py PyList {
+    pub fn copy_in_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: u32,
+    ) -> PyResult<Bound<'py, PyList>> {
         self.inner.copy_in_neighbors(py, node)
     }
 
@@ -117,19 +133,19 @@ impl DiGraph {
         self.inner.__repr__()
     }
 
-    #[args(layout = "None")]
+    #[pyo3(signature = (layout = None))]
     pub fn to_undirected(&self, layout: Option<Layout>) -> Graph {
         let g = self.inner.to_undirected(layout.map(CsrLayout::from));
         Graph::new(g.load_micros, g)
     }
 
     /// Run Page Rank on this graph.
-    #[args(
-        "*",
-        max_iterations = "PageRankConfig::DEFAULT_MAX_ITERATIONS",
-        tolerance = "PageRankConfig::DEFAULT_TOLERANCE",
-        damping_factor = "PageRankConfig::DEFAULT_DAMPING_FACTOR"
-    )]
+    #[pyo3(signature = (
+        *,
+        max_iterations = PageRankConfig::DEFAULT_MAX_ITERATIONS,
+        tolerance = PageRankConfig::DEFAULT_TOLERANCE,
+        damping_factor = PageRankConfig::DEFAULT_DAMPING_FACTOR,
+    ))]
     pub fn page_rank(
         &self,
         py: Python<'_>,
@@ -142,12 +158,12 @@ impl DiGraph {
     }
 
     /// Run Weakly Connected Compontents on this graph.
-    #[args(
-        "*",
-        chunk_size = "WccConfig::DEFAULT_CHUNK_SIZE",
-        neighbor_rounds = "WccConfig::DEFAULT_NEIGHBOR_ROUNDS",
-        sampling_size = "WccConfig::DEFAULT_SAMPLING_SIZE"
-    )]
+    #[pyo3(signature = (
+        *,
+        chunk_size = WccConfig::DEFAULT_CHUNK_SIZE,
+        neighbor_rounds = WccConfig::DEFAULT_NEIGHBOR_ROUNDS,
+        sampling_size = WccConfig::DEFAULT_SAMPLING_SIZE,
+    ))]
     pub fn wcc(
         &self,
         py: Python<'_>,

--- a/crates/mate/src/graphs/graph.rs
+++ b/crates/mate/src/graphs/graph.rs
@@ -5,7 +5,7 @@ use numpy::{PyArray1, PyArray2};
 use pyo3::{prelude::*, types::PyList};
 use std::path::PathBuf;
 
-pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Graph>()?;
     Ok(())
 }
@@ -28,7 +28,7 @@ impl Graph {
 impl Graph {
     /// Load a graph in the provided format
     #[staticmethod]
-    #[args(layout = "None", file_format = "FileFormat::Graph500")]
+    #[pyo3(signature = (path, layout = None, file_format = FileFormat::Graph500))]
     pub fn load(
         py: Python<'_>,
         path: PathBuf,
@@ -41,16 +41,16 @@ impl Graph {
 
     /// Convert a numpy 2d-array into a graph.
     #[staticmethod]
-    #[args(layout = "None")]
-    pub fn from_numpy(np: &PyArray2<u32>, layout: Option<Layout>) -> PyResult<Self> {
+    #[pyo3(signature = (np, layout = None))]
+    pub fn from_numpy(np: &Bound<'_, PyArray2<u32>>, layout: Option<Layout>) -> PyResult<Self> {
         let g = PyGraph::from_numpy(np, layout)?;
         Ok(Self::new(g.load_micros, g))
     }
 
     /// Convert a pandas dataframe into a graph.
     #[staticmethod]
-    #[args(layout = "None")]
-    pub fn from_pandas(py: Python<'_>, data: PyObject, layout: Option<Layout>) -> PyResult<Self> {
+    #[pyo3(signature = (data, layout = None))]
+    pub fn from_pandas(py: Python<'_>, data: Py<PyAny>, layout: Option<Layout>) -> PyResult<Self> {
         let g = PyGraph::from_pandas(py, data, layout)?;
         Ok(Self::new(g.load_micros, g))
     }
@@ -74,14 +74,18 @@ impl Graph {
     ///
     /// This functions returns a numpy array that directly references this graph without
     /// making a copy of the data.
-    pub fn neighbors<'py>(&self, py: Python<'py>, node: u32) -> PyResult<&'py PyArray1<u32>> {
+    pub fn neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: u32,
+    ) -> PyResult<Bound<'py, PyArray1<u32>>> {
         self.inner.neighbors(py, node)
     }
 
     /// Returns all nodes connected to the given node.
     ///
     /// This function returns a copy of the data as a Python list.
-    pub fn copy_neighbors<'py>(&self, py: Python<'py>, node: u32) -> &'py PyList {
+    pub fn copy_neighbors<'py>(&self, py: Python<'py>, node: u32) -> PyResult<Bound<'py, PyList>> {
         self.inner.copy_neighbors(py, node)
     }
 

--- a/crates/mate/src/graphs/mod.rs
+++ b/crates/mate/src/graphs/mod.rs
@@ -7,7 +7,7 @@ use ::graph::prelude::{
 };
 use numpy::{
     ndarray::{iter::AxisIter, ArrayView2, Ix1},
-    Element, PyArray1, PyArray2,
+    Element, PyArray1, PyArray2, PyArrayMethods,
 };
 use pyo3::{
     exceptions::{PyTypeError, PyValueError},
@@ -29,7 +29,7 @@ mod shared_slice;
 pub(crate) use self::graph::Graph;
 pub(crate) use self::shared_slice::{NumpyType, SharedSlice};
 
-pub(crate) fn register(py: Python, m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Layout>()?;
     m.add_class::<FileFormat>()?;
 
@@ -41,8 +41,8 @@ pub(crate) fn register(py: Python, m: &PyModule) -> PyResult<()> {
 
 /// Defines how the neighbor list of individual nodes are organized within the
 /// CSR target array.
-#[derive(Clone, Copy, Debug)]
-#[pyclass]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[pyclass(eq, eq_int, from_py_object)]
 pub enum Layout {
     /// Neighbor lists are sorted and may contain duplicate target ids.
     Sorted,
@@ -55,8 +55,8 @@ pub enum Layout {
 }
 
 /// Defines the file format of an input file.
-#[derive(Clone, Copy, Debug)]
-#[pyclass]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[pyclass(eq, eq_int, from_py_object)]
 pub enum FileFormat {
     /// The input in a binary Graph500 format.
     Graph500,
@@ -142,7 +142,7 @@ where
         GraphError: From<G::Error>,
     {
         let (graph, took) = py
-            .allow_threads(move || {
+            .detach(move || {
                 let (graph, load_micros) = time(move || {
                     let mut b = GraphBuilder::new();
                     if let Some(layout) = layout {
@@ -166,7 +166,7 @@ impl<NI, G> PyGraph<NI, G>
 where
     NI: Idx,
 {
-    fn from_numpy(np: &PyArray2<NI>, layout: Option<Layout>) -> PyResult<Self>
+    fn from_numpy(np: &Bound<'_, PyArray2<NI>>, layout: Option<Layout>) -> PyResult<Self>
     where
         NI: Element,
         for<'a> G: From<(ArrayEdgeList<'a, NI>, CsrLayout)>,
@@ -177,15 +177,17 @@ where
         Ok(Self::from_edge_list(el, layout))
     }
 
-    fn from_pandas(py: Python<'_>, data: PyObject, layout: Option<Layout>) -> PyResult<Self>
+    fn from_pandas(py: Python<'_>, data: Py<PyAny>, layout: Option<Layout>) -> PyResult<Self>
     where
         NI: Element,
         for<'a> G: From<(ArrayEdgeList<'a, NI>, CsrLayout)>,
     {
+        use pyo3::types::IntoPyDict;
         let to_numpy = data.getattr(py, "to_numpy")?;
-        let np = to_numpy.call0(py)?;
-        let np = unsafe { PyArray2::from_owned_ptr(py, np.into_ptr()) };
-        Self::from_numpy(np, layout)
+        let kwargs = [("dtype", NI::get_dtype(py))].into_py_dict(py)?;
+        let np = to_numpy.call(py, (), Some(&kwargs))?;
+        let np = np.bind(py).cast::<PyArray2<NI>>()?.clone();
+        Self::from_numpy(&np, layout)
     }
 
     /// Load a graph from an edge list
@@ -296,7 +298,7 @@ where
         &self,
         py: Python<'py>,
         node: NI,
-    ) -> PyResult<&'py PyArray1<NI>>
+    ) -> PyResult<Bound<'py, PyArray1<NI>>>
     where
         for<'a> G: DirectedNeighbors<NI, NeighborsIterator<'a> = std::slice::Iter<'a, NI>>,
     {
@@ -309,7 +311,11 @@ where
     ///
     /// This functions returns a numpy array that directly references this graph without
     /// making a copy of the data.
-    pub(crate) fn in_neighbors<'py>(&self, py: Python<'py>, node: NI) -> PyResult<&'py PyArray1<NI>>
+    pub(crate) fn in_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: NI,
+    ) -> PyResult<Bound<'py, PyArray1<NI>>>
     where
         for<'a> G: DirectedNeighbors<NI, NeighborsIterator<'a> = std::slice::Iter<'a, NI>>,
     {
@@ -321,7 +327,11 @@ where
     ///
     /// This functions returns a numpy array that directly references this graph without
     /// making a copy of the data.
-    pub(crate) fn neighbors<'py>(&self, py: Python<'py>, node: NI) -> PyResult<&'py PyArray1<NI>>
+    pub(crate) fn neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: NI,
+    ) -> PyResult<Bound<'py, PyArray1<NI>>>
     where
         for<'a> G: UndirectedNeighbors<NI, NeighborsIterator<'a> = std::slice::Iter<'a, NI>>,
     {
@@ -332,43 +342,55 @@ where
 
 impl<NI, G> PyGraph<NI, G>
 where
-    NI: Idx + ToPyObject,
+    NI: Idx + for<'py> IntoPyObject<'py>,
     G: GraphTrait<NI>,
 {
     /// Returns all nodes which are connected in outgoing direction to the given node,
     /// i.e., the given node is the source node of the connecting edge.
     ///
     /// This function returns a copy of the data as a Python list.
-    pub(crate) fn copy_out_neighbors<'py>(&self, py: Python<'py>, node: NI) -> &'py PyList
+    pub(crate) fn copy_out_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: NI,
+    ) -> PyResult<Bound<'py, PyList>>
     where
         G: DirectedNeighbors<NI>,
         for<'a> G::NeighborsIterator<'a>: ExactSizeIterator,
     {
-        PyList::new(py, self.g.out_neighbors(node))
+        PyList::new(py, self.g.out_neighbors(node).copied())
     }
 
     /// Returns all nodes which are connected in incoming direction to the given node,
     /// i.e., the given node is the target node of theconnecting edge.
     ///
     /// This function returns a copy of the data as a Python list.
-    pub(crate) fn copy_in_neighbors<'py>(&self, py: Python<'py>, node: NI) -> &'py PyList
+    pub(crate) fn copy_in_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: NI,
+    ) -> PyResult<Bound<'py, PyList>>
     where
         G: DirectedNeighbors<NI>,
         for<'a> G::NeighborsIterator<'a>: ExactSizeIterator,
     {
-        PyList::new(py, self.g.in_neighbors(node))
+        PyList::new(py, self.g.in_neighbors(node).copied())
     }
 
     /// Returns all nodes which are connected in incoming direction to the given node,
     /// i.e., the given node is the target node of theconnecting edge.
     ///
     /// This function returns a copy of the data as a Python list.
-    pub(crate) fn copy_neighbors<'py>(&self, py: Python<'py>, node: NI) -> &'py PyList
+    pub(crate) fn copy_neighbors<'py>(
+        &self,
+        py: Python<'py>,
+        node: NI,
+    ) -> PyResult<Bound<'py, PyList>>
     where
         G: UndirectedNeighbors<NI>,
         for<'a> G::NeighborsIterator<'a>: ExactSizeIterator,
     {
-        PyList::new(py, self.g.neighbors(node))
+        PyList::new(py, self.g.neighbors(node).copied())
     }
 }
 

--- a/crates/mate/src/graphs/shared_slice.rs
+++ b/crates/mate/src/graphs/shared_slice.rs
@@ -1,7 +1,7 @@
 use graph::prelude::{DirectedNeighbors, Idx, UndirectedNeighbors};
 use numpy::{
     npyffi::{types::NPY_TYPES, NpyTypes, NPY_ARRAY_DEFAULT, NPY_ARRAY_WRITEABLE},
-    PyArray, PyArray1, PY_ARRAY_API,
+    PyArray1, PY_ARRAY_API,
 };
 use pyo3::{prelude::*, types::PyCapsule};
 use std::{ffi::CString, fmt::Debug, os::raw::c_void, sync::Arc};
@@ -106,7 +106,10 @@ impl SharedSlice {
         self.len
     }
 
-    pub fn into_numpy<NI: NumpyType>(mut self, py: Python<'_>) -> PyResult<&PyArray1<NI>> {
+    pub fn into_numpy<NI: NumpyType>(
+        mut self,
+        py: Python<'_>,
+    ) -> PyResult<Bound<'_, PyArray1<NI>>> {
         assert_eq!(
             NI::NP_TYPE,
             self.np_tpe,
@@ -157,7 +160,10 @@ impl SharedSlice {
             PY_ARRAY_API.PyArray_SetBaseObject(py, arr.cast(), capsule.into_ptr());
         }
 
-        unsafe { Ok(PyArray::from_owned_ptr(py, arr)) }
+        let arr = unsafe { Bound::from_owned_ptr(py, arr) };
+        // SAFETY: the array was created above with the numpy type matching `NI`,
+        // which is asserted at the top of this function.
+        Ok(unsafe { arr.cast_into_unchecked::<PyArray1<NI>>() })
     }
 }
 
@@ -204,3 +210,7 @@ impl SharedConst {
 }
 
 unsafe impl Send for SharedConst {}
+
+// SAFETY: the pointer refers to immutable data that is kept alive by the
+// `owner` field of `SharedSlice` and is only ever read from.
+unsafe impl Sync for SharedConst {}

--- a/crates/mate/src/lib.rs
+++ b/crates/mate/src/lib.rs
@@ -2,8 +2,7 @@
 
 use ::graph::prelude::Error as GError;
 use pyo3::{
-    exceptions::PyValueError,
-    prelude::{pymodule, IntoPy, PyErr, PyModule, PyObject, PyResult, Python},
+    exceptions::PyValueError, prelude::*, types::PyModule, Bound, IntoPyObjectExt, Py, PyAny,
     PyErrArguments,
 };
 use pyo3_log::{Caching, Logger};
@@ -16,8 +15,11 @@ mod wcc;
 struct GraphError(GError);
 
 impl PyErrArguments for GraphError {
-    fn arguments(self, py: Python) -> PyObject {
-        self.0.to_string().into_py(py)
+    fn arguments(self, py: Python<'_>) -> Py<PyAny> {
+        self.0
+            .to_string()
+            .into_py_any(py)
+            .expect("converting a string to a Python object is infallible")
     }
 }
 
@@ -29,7 +31,8 @@ impl From<GraphError> for PyErr {
 
 /// Python API for the graph crate
 #[pymodule]
-fn graph_mate(py: Python, m: &PyModule) -> PyResult<()> {
+fn graph_mate(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
     Logger::new(py, Caching::LoggersAndLevels)?
         .install()
         .unwrap();

--- a/crates/mate/src/page_rank.rs
+++ b/crates/mate/src/page_rank.rs
@@ -7,7 +7,7 @@ use numpy::PyArray1;
 use pyo3::prelude::*;
 use std::time::{Duration, Instant};
 
-pub(crate) fn register(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PageRankResult>()?;
     Ok(())
 }
@@ -18,7 +18,7 @@ where
     G: GraphTrait<NI> + DirectedDegrees<NI> + DirectedNeighbors<NI> + Sync,
     C: Into<Option<PageRankConfig>> + Send,
 {
-    py.allow_threads(move || inner_page_rank(graph, config))
+    py.detach(move || inner_page_rank(graph, config))
 }
 
 fn inner_page_rank<NI, G>(graph: &G, config: impl Into<Option<PageRankConfig>>) -> PageRankResult
@@ -39,7 +39,7 @@ where
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct PageRankResult {
     scores: SharedSlice,
@@ -64,7 +64,7 @@ impl std::fmt::Debug for PageRankResult {
 
 #[pymethods]
 impl PageRankResult {
-    pub fn scores<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<f32>> {
+    pub fn scores<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f32>>> {
         self.scores.clone().into_numpy(py)
     }
 

--- a/crates/mate/src/triangle_count.rs
+++ b/crates/mate/src/triangle_count.rs
@@ -2,7 +2,7 @@ use graph::prelude::{global_triangle_count as tc, Graph as GraphTrait, Idx, Undi
 use pyo3::prelude::*;
 use std::time::{Duration, Instant};
 
-pub(crate) fn register(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TriangleCountResult>()?;
     Ok(())
 }
@@ -12,7 +12,7 @@ where
     NI: Idx,
     G: GraphTrait<NI> + UndirectedNeighbors<NI> + Sync,
 {
-    py.allow_threads(move || inner_triangle_count(graph))
+    py.detach(move || inner_triangle_count(graph))
 }
 
 fn inner_triangle_count<NI, G>(graph: &G) -> TriangleCountResult
@@ -26,7 +26,7 @@ where
     TriangleCountResult { triangles, micros }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct TriangleCountResult {
     #[pyo3(get)]

--- a/crates/mate/src/wcc.rs
+++ b/crates/mate/src/wcc.rs
@@ -9,7 +9,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::time::{Duration, Instant};
 
-pub(crate) fn register(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<WccResult>()?;
     Ok(())
 }
@@ -20,7 +20,7 @@ where
     G: GraphTrait<NI> + DirectedDegrees<NI> + DirectedNeighbors<NI> + Sync,
     C: Into<Option<WccConfig>> + Send,
 {
-    py.allow_threads(move || inner_wcc(graph, config))
+    py.detach(move || inner_wcc(graph, config))
 }
 
 fn inner_wcc<NI, G>(graph: &G, config: impl Into<Option<WccConfig>>) -> WccRes<NI>
@@ -46,7 +46,7 @@ pub struct WccRes<NI> {
     _phantom: PhantomData<NI>,
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct WccResult {
     components: SharedSlice,
@@ -77,7 +77,7 @@ impl std::fmt::Debug for WccResult {
 
 #[pymethods]
 impl WccResult {
-    pub fn components<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<u32>> {
+    pub fn components<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<u32>>> {
         self.components.clone().into_numpy(py)
     }
 

--- a/crates/server/src/actions.rs
+++ b/crates/server/src/actions.rs
@@ -95,16 +95,11 @@ pub enum CsrLayoutRef {
     Deduplicated,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Default, Deserialize, Debug)]
 pub enum Orientation {
+    #[default]
     Directed,
     Undirected,
-}
-
-impl Default for Orientation {
-    fn default() -> Self {
-        Self::Directed
-    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -142,15 +137,15 @@ impl TryFrom<FlightDescriptor> for CreateGraphCommand {
     type Error = Status;
 
     fn try_from(descriptor: FlightDescriptor) -> Result<Self, Self::Error> {
-        match DescriptorType::from_i32(descriptor.r#type) {
-            None => Err(Status::invalid_argument(format!(
+        match DescriptorType::try_from(descriptor.r#type) {
+            Err(_) => Err(Status::invalid_argument(format!(
                 "unsupported descriptor type: {}",
                 descriptor.r#type
             ))),
-            Some(DescriptorType::Cmd) => {
+            Ok(DescriptorType::Cmd) => {
                 serde_json::from_slice::<Self>(&descriptor.cmd).map_err(from_json_error)
             }
-            Some(descriptor_type) => Err(Status::invalid_argument(format!(
+            Ok(descriptor_type) => Err(Status::invalid_argument(format!(
                 "Expected command, got {descriptor_type:?}"
             ))),
         }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -16,8 +16,8 @@ use arrow::{datatypes::Schema, ipc::writer::IpcWriteOptions};
 use arrow_flight::utils::flight_data_to_arrow_batch;
 use arrow_flight::{
     flight_service_server::FlightService, Action, ActionType, Criteria, Empty, FlightData,
-    FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult, SchemaAsIpc,
-    SchemaResult, Ticket,
+    FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PollInfo, PutResult,
+    SchemaAsIpc, SchemaResult, Ticket,
 };
 use futures::stream::BoxStream;
 use futures::StreamExt;
@@ -80,13 +80,19 @@ impl FlightService for FlightServiceImpl {
         // Imho, there is no need to implement lazy batch computation.
         let data_gen = writer::IpcDataGenerator::default();
         let mut dictionary_tracker = writer::DictionaryTracker::new(false);
+        let mut compression_context = writer::CompressionContext::default();
 
         let record_batches = property_entry
             .batches
             .iter()
             .map(|batch| {
                 let (_, encoded_batch) = data_gen
-                    .encoded_batch(batch, &mut dictionary_tracker, &ipc_write_options)
+                    .encode(
+                        batch,
+                        &mut dictionary_tracker,
+                        &ipc_write_options,
+                        &mut compression_context,
+                    )
                     .expect("DictionaryTracker configured above to not error on replacement");
                 encoded_batch.into()
             })
@@ -275,6 +281,13 @@ impl FlightService for FlightServiceImpl {
         &self,
         _request: Request<FlightDescriptor>,
     ) -> FlightResult<Response<FlightInfo>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> FlightResult<Response<PollInfo>> {
         Err(Status::unimplemented("Not yet implemented"))
     }
 


### PR DESCRIPTION
## Notable dependency jumps and the code changes they forced

| Dependency | From → To | Required changes |
|---|---|---|
| arrow / arrow-flight | 45 → **59** | New `poll_flight_info` method on `FlightService`; `DescriptorType::try_from` replaces `from_i32`; `IpcDataGenerator::encode` with `CompressionContext` replaces `encoded_batch` |
| tonic | 0.9 → **0.14** | Transitive via arrow-flight (now split with `tonic-prost`); no server code changes beyond the above |
| pyo3 / rust-numpy | 0.17 → **0.28** | Full Bound-API migration in `graph_mate`: `#[args]` → `#[pyo3(signature)]`, `&PyModule` → `&Bound<PyModule>`, `IntoPyObject` replaces `IntoPy`/`ToPyObject`, `Bound<PyArray1>` returns, `Sync` impl for the shared-slice pointer wrapper, `py.detach` replaces `py.allow_threads`, enums get `eq, eq_int, from_py_object`, result classes get `skip_from_py_object` |
| polars | 0.25 → **0.54** | `usage-demo` example ported: `Column::new` with `PlSmallStr`, two-arg `DataFrame::new`, per-Series stats (DataFrame-level `min`/`max`/`mean`/`median` were removed), 3-arg `unique` |
| atoi | 2 → **3** | Dropped `usize`/`isize` impls; `Idx::parse` and `ParseValue` now parse via `u64`/`i64` proxies and cast |
| atomic | 0.5 → **0.6** | `Atomic<T>` now requires `bytemuck::NoUninit`; added to the `Idx` supertrait bounds |
| rand | 0.8 → **0.10** | `gen_range` → `random_range` (now on the `RngExt` trait) in benches |
| criterion | 0.4 → **0.8** | `criterion::black_box` deprecated → `std::hint::black_box` |
| thiserror | 1 → **2**, dashmap 5 → **6**, itertools 0.10 → **0.14**, tokio-tar → **astral-tokio-tar 0.6** | No source changes (astral fork keeps the `tokio_tar` lib name) |

## Bug fixed along the way

`Graph::from_pandas` / `DiGraph::from_pandas` previously passed pandas' default `int64` buffer through an **unchecked pointer cast** to a `u32` array — it only produced correct results on little-endian machines with small non-negative ids. The pyo3 0.28 checked cast surfaced this; the fix requests the correct dtype directly via `to_numpy(dtype=...)`, which is correct on any platform.

## Python packaging (graph_mate)

- Minimum supported Python raised to **3.10** (3.8 and 3.9 are EOL): `abi3-py310`, `requires-python = ">=3.10"`, classifiers now 3.10–3.14.
- CI wheel-build Python bumped from 3.8 to 3.10 to match the new abi3 tag.

## Misc

- `dotgraph` bench now declares `required-features = ["dotgraph"]` so `--all-targets` skips it instead of failing without the feature.
- Fixed new-in-1.91 `mismatched_lifetime_syntaxes` lints.
