### PR TITLE
Fix release workflows and bump action versions

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
-      - uses: chainguard-dev/actions/setup-gitsign@main
+      - uses: chainguard-dev/actions/setup-gitsign@v1.6.22
       - name: Install cargo-release
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-release
       - uses: cargo-bins/release-pr@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -110,7 +110,7 @@ jobs:
           toolchain: stable
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - run: pip install maturin
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -132,7 +132,7 @@ jobs:
           toolchain: stable
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - run: pip install maturin
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -181,49 +181,14 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  macos-x86_64:
-    name: Package graph_mate for Mac x86_64
-    runs-on: macos-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.crate == 'graph_mate'
-    needs: test_python
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - name: Set up Rust cache
-        uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-      - name: Build wheels - x86_64
-        uses: PyO3/maturin-action@v1
-        with:
-          target: x86_64
-          args: ${{ env.MATURIN_ARGS }} --sdist
-      - name: Install built wheel - x86_64
-        run: |
-          pip install dist/${{ env.PY_PACKAGE_NAME }}-*.whl --force-reinstall
-          python -c "import ${{ env.PY_PACKAGE_NAME }}"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels
-          path: dist
-
   macos-universal:
     name: Package graph_mate for Mac Universal
     runs-on: macos-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.crate == 'graph_mate'
+    if: startsWith(github.ref, 'refs/tags/') && (inputs.crate == 'graph_mate' || inputs.crate == 'all')
     needs: test_python
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -232,36 +197,35 @@ jobs:
           toolchain: stable
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
       - name: Build wheels - universal2
         uses: PyO3/maturin-action@v1
         with:
           target: universal2-apple-darwin
-          args: ${{ env.MATURIN_ARGS }}
+          args: ${{ env.MATURIN_ARGS }} --sdist
       - name: Install built wheel - universal2
         run: |
           pip install dist/${{ env.PY_PACKAGE_NAME }}-*universal2.whl --force-reinstall
           python -c "import ${{ env.PY_PACKAGE_NAME }}"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
-          name: wheels
+          name: wheels-macos-universal2
           path: dist
 
   windows:
     name: Package graph_mate for Windows
     runs-on: windows-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.crate == 'graph_mate'
+    if: startsWith(github.ref, 'refs/tags/') && (inputs.crate == 'graph_mate' || inputs.crate == 'all')
     needs: test_python
     strategy:
       matrix:
         target: [x64, x86]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -270,7 +234,7 @@ jobs:
           toolchain: stable
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.target }}
@@ -285,22 +249,22 @@ jobs:
           python -m pip install dist/${{ env.PY_PACKAGE_NAME }}-*.whl --force-reinstall
           python -c "import ${{ env.PY_PACKAGE_NAME }}"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.target }}
           path: dist
 
   linux:
     name: Package graph_mate for Linux
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.crate == 'graph_mate'
+    if: startsWith(github.ref, 'refs/tags/') && (inputs.crate == 'graph_mate' || inputs.crate == 'all')
     needs: test_python
     strategy:
       matrix:
         target: [x86_64, i686]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -309,7 +273,7 @@ jobs:
           toolchain: stable
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
@@ -325,9 +289,9 @@ jobs:
           pip install dist/${{ env.PY_PACKAGE_NAME }}-*.whl --force-reinstall
           python -c "import ${{ env.PY_PACKAGE_NAME }}"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.target }}
           path: dist
 
   release_crate:
@@ -343,7 +307,7 @@ jobs:
       - test_python
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -361,7 +325,7 @@ jobs:
   release_graph_mate:
     name: Release graph_mate
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.crate == 'graph_mate'
+    if: startsWith(github.ref, 'refs/tags/') && (inputs.crate == 'graph_mate' || inputs.crate == 'all')
     needs:
       - check
       - test
@@ -370,14 +334,14 @@ jobs:
       - clippy
       - test_python
       - macos-universal
-      - macos-x86_64
       - windows
       - linux
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
-          name: wheels
-      - uses: actions/setup-python@v5
+          pattern: wheels-*
+          merge-multiple: true
+      - uses: actions/setup-python@v6
       - name: Publish to PyPi
         env:
           TWINE_USERNAME: __token__
@@ -397,13 +361,9 @@ jobs:
       - fmt
       - clippy
       - test_python
-      - macos-universal
-      - macos-x86_64
-      - windows
-      - linux
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Setup Rust
@@ -416,7 +376,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
+        run: cargo publish --workspace
 
 # Parts of this Actions file is taken and adapted from Ruff under MIT License:
 # https://github.com/charliermarsh/ruff/blob/e00bcd19f51f33a399751d2a7b854d59024473ca/.github/workflows/ruff.yaml


### PR DESCRIPTION
## Summary

The release paths in `rust.yml` had two latent breakages that would have failed the next `graph_mate` or `all` release, plus several actions a major version or two behind. This PR fixes both and modernizes the action pins.

### Release-breaking fixes
- **Artifact name conflict**: all wheel-packaging jobs uploaded to `name: wheels`, which `upload-artifact@v4+` rejects (v3 merged same-name uploads, v4 fails with 409). `graph_mate` hasn't been released since the v4 bump, so this path never ran. Each job now uploads a unique artifact (`wheels-<platform>-<target>`) and `release_graph_mate` downloads them with `pattern: wheels-*` + `merge-multiple: true`.
- **`release_all` was silently skipped**: it `need`ed the packaging jobs, which only ran for `crate == 'graph_mate'` — a job whose needs are skipped is itself skipped. It now depends only on the CI jobs and publishes with `cargo publish --workspace` (bare `cargo publish` errors in a virtual workspace). With `app`/`server`/`mate` at `publish = false`, this publishes exactly `graph_builder` and `graph` in dependency order.

### Behavior changes
- Dispatching with `crate: all` now also builds wheels and publishes `graph_mate` to PyPI, so "all" really means all.
- macOS wheels are **universal2 only**: the x86_64-only job is dropped (the universal2 wheel covers Intel Macs), the sdist build moved to the universal2 job, and the install smoke test runs on the runner's native arm64 Python instead of x64-under-Rosetta — `macos-latest` runners are arm64 now.

### Version bumps
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v5 |
| `actions/download-artifact` | v4 | v6 |
| `baptiste0928/cargo-install` | v2 | v3 |
| `chainguard-dev/actions/setup-gitsign` | `@main` (moving branch) | `@v1.6.22` |

## Test plan
- [x] YAML parses
- [ ] CI on this PR validates workflow syntax
- [ ] Release jobs are tag-gated and can only be verified on the next actual release dispatch — `graph_mate` (or `all`) exercises the new artifact handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)