### PR TITLE
release: graph_mate v0.2.0

### DIFF
--- a/crates/mate/Cargo.toml
+++ b/crates/mate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph_mate"
-version = "0.1.1"
+version = "0.2.0"
 description = "A library of high-performant graph algorithms."
 keywords = ["graph", "algorithms", "parallel"]
 publish = false

--- a/crates/mate/pyproject.toml
+++ b/crates/mate/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "graph_mate"
-version = "0.1.1"
+version = "0.2.0"
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Releases graph_mate 0.2.0 to PyPI.

Minor bump (not patch) because the minimum supported Python was raised from 3.8 to 3.10 (abi3-py310 wheels) since 0.1.1.

Created manually because `cargo-bins/release-pr` cannot see this crate: `publish = false` (PyPI-only) makes cargo-workspaces treat it as private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)