### PR TITLE
Link advapi32 on Windows for graph_mate

### DIFF
--- a/crates/mate/build.rs
+++ b/crates/mate/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // nanorand (via graph_builder) calls RtlGenRandom (SystemFunction036) but does
+    // not declare the advapi32 dependency itself; Rust no longer links it implicitly.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}


### PR DESCRIPTION
The graph_mate 0.2.0 release run failed linking the Windows wheels: `unresolved external symbol SystemFunction036` (RtlGenRandom), referenced by nanorand via graph_builder. nanorand 0.7 doesn't declare its advapi32 dependency and Rust stopped linking advapi32 implicitly, which is why this only appears now — the Windows packaging jobs run exclusively on release tags and the last graph_mate release predates the toolchain change.

A `build.rs` in graph_mate links advapi32 on Windows, fixing both the CI wheel builds and sdist builds on Windows user machines.

Failed run: https://github.com/neo4j-labs/graph/actions/runs/27277863582

🤖 Generated with [Claude Code](https://claude.com/claude-code)